### PR TITLE
parser: handle scheme-less uris

### DIFF
--- a/ramlfications/parser.py
+++ b/ramlfications/parser.py
@@ -724,7 +724,7 @@ def create_node(name, raw_data, method, parent, root):
         """Set resource's absolute URI path."""
         uri = root.base_uri + path()
         proto = protocols()
-        if proto:
+        if proto and '://' in uri:
             uri = uri.split("://", 1)
             uri = uri[-1]
 
@@ -750,7 +750,7 @@ def create_node(name, raw_data, method, parent, root):
                       data=raw_data,
                       parent=parent)
         objects_to_inherit = [
-            "traits", "types", "method", "resource", "parent"
+            "traits", "types", "method", "resource", "parent", "root"
         ]
         inherited = get_inherited("protocols", objects_to_inherit, **kwargs)
         trait = inherited["traits"]
@@ -758,7 +758,10 @@ def create_node(name, raw_data, method, parent, root):
         meth = inherited["method"]
         res = inherited["resource"]
         parent_ = inherited["parent"]
-        default = [root.base_uri.split("://")[0].upper()]
+        if '://' in root.base_uri:
+            default = [root.base_uri.split("://")[0].upper()]
+        else:
+            default = inherited["root"]
 
         return meth or r_type or trait or res or parent_ or default
 

--- a/ramlfications/parser.py
+++ b/ramlfications/parser.py
@@ -725,9 +725,9 @@ def create_node(name, raw_data, method, parent, root):
         uri = root.base_uri + path()
         proto = protocols()
         if proto:
-            uri = uri.split("://")
-            if len(uri) == 2:
-                uri = uri[1]
+            uri = uri.split("://", 1)
+            uri = uri[-1]
+
             if root.protocols:
                 _proto = list(set(root.protocols) & set(proto))
                 # if resource protocols and root protocols share a protocol


### PR DESCRIPTION
This code seems to depend on `.split('://')` returning a 2-element sequence. This doesn't seem to be a valid assumption:

> The baseUri property's value MUST conform to the URI specification [RFC2396] or a Level 1 Template URI as defined in RFC 6570

From my reading of RFC 6570, it seems stuff like: `{endpoint}/api`, where `endpoint` is something like `http://foo`, would be completely valid--or at least that isn't explicitly prohibited.

With such a baseUri, the current code would end up attempting a `str + list` concatenation, which is a `TypeError`.

I'm not sure of the best way to handle this--I also think logic like "if no uri scheme is present in the un-expanded template uri, the rest of this code will be invalid anyway, so just return uri" would be also valid.

Would you like a regression test for this as well?
