### PR TITLE
raml: preserve tree structure in parsed nodes

### DIFF
--- a/ramlfications/parser.py
+++ b/ramlfications/parser.py
@@ -53,7 +53,7 @@ def parse_raml(loaded_raml, config):
     root.traits = create_traits(root.raml_obj, root)
     root.resource_types = create_resource_types(root.raml_obj, root)
     root.resources = create_resources(root.raml_obj, [], root,
-                                      parent=None)
+                                      parent=root)
 
     if validate:
         attr.validate(root)  # need to validate again for root node
@@ -676,6 +676,7 @@ def create_resources(node, resources, root, parent):
                                         parent=parent,
                                         root=root)
                     resources.append(child)
+                    parent.children.append(child)
             # inherit resource type methods
             elif "type" in list(iterkeys(v)):
                 if hasattr(assigned, "method"):
@@ -688,6 +689,7 @@ def create_resources(node, resources, root, parent):
                                     parent=parent,
                                     root=root)
                 resources.append(child)
+                parent.children.append(child)
             else:
                 child = create_node(name=k,
                                     raw_data=v,
@@ -695,6 +697,7 @@ def create_resources(node, resources, root, parent):
                                     parent=parent,
                                     root=root)
                 resources.append(child)
+                parent.children.append(child)
             resources = create_resources(child.raw, resources, root, child)
     return resources
 
@@ -716,7 +719,7 @@ def create_node(name, raw_data, method, parent, root):
     def path():
         """Set resource's relative URI path."""
         parent_path = ""
-        if parent:
+        if parent and parent != root:
             parent_path = parent.path
         return parent_path + name
 

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -72,6 +72,7 @@ class RootNode(object):
     config           = attr.ib(repr=False,
                                validator=attr.validators.instance_of(dict))
     errors           = attr.ib(repr=False)
+    children         = attr.ib(repr=False, default=attr.Factory(list))
 
 
 @attr.s
@@ -213,6 +214,7 @@ class ResourceNode(BaseNode):
     resource_type    = attr.ib(repr=False)
     secured_by       = attr.ib(repr=False)
     security_schemes = attr.ib(repr=False)
+    children         = attr.ib(repr=False, default=attr.Factory(list))
 
     def _inherit_type(self):
         for p in METHOD_PROPERTIES:


### PR DESCRIPTION
The idea is to be able to traverse nodes in the same tree structure as the source raml, in addition to the flat resources list. A new `children` attribute is added to `RootNode` and `ResourceNode` to accomplish this, and populated during `create_resources`.

This also changes the `parent` node of first-level resources from `None` to the root node--this is so that child/parent traversing can start from the root node, instead of some arbitrary resource.
